### PR TITLE
Update to GeMS_MetadataCSDGM2_Arc10.py

### DIFF
--- a/Scripts/GeMS_MetadataCSDGM2_Arc10.py
+++ b/Scripts/GeMS_MetadataCSDGM2_Arc10.py
@@ -143,6 +143,7 @@ def __updateEdom(fld, defs, dom):
             attr = attrlabl.parentNode
             attrdomv = dom.createElement('attrdomv')
             for k in defs.iteritems():
+                attrdomv = dom.createElement('attrdomv')
                 edom = dom.createElement('edom')
                 edomv = __newElement(dom,'edomv',k[0])
                 edomvd = __newElement(dom,'edomvd',k[1][0])
@@ -152,6 +153,7 @@ def __updateEdom(fld, defs, dom):
                     edomvds = __newElement(dom,'edomvds',k[1][1])
                     edom.appendChild(edomvds)                                
                 attrdomv.appendChild(edom)
+                attr.appendChild(attrdomv)
             __appendOrReplace(attr,attrdomv,'attrdomv')
     return dom
 


### PR DESCRIPTION
def _updateEdom now nests each Enumerated Domain within an Attribute Domain Values element, eg:

Attribute:
  Attribute_Label: MapUnit
  Attribute_Definition: Short plain-text identifier of the map unit. Foreign key to DescriptionOfMapUnits table.
  Attribute_Definition_Source: GeMS
  Attribute_Domain_Values:
    Enumerated_Domain:
      Enumerated_Domain_Value: lcl1
      Enumerated_Domain_Value_Definition: Lakeshore Cone lava 1
      Enumerated_Domain_Value_Definition_Source: this report, table DescriptionOfMapUnits
  Attribute_Domain_Values:
    Enumerated_Domain:
       Enumerated_Domain_Value: cdl
       Enumerated_Domain_Value_Definition: dammer lava
       Enumerated_Domain_Value_Definition_Source: this report, table DescriptionOfMapUnits
  Attribute_Domain_Values:
       Enumerated_Domain:
         Enumerated_Domain_Value: cfe
         Enumerated_Domain_Value_Definition: Ignimbrite of CFE
         Enumerated_Domain_Value_Definition_Source: this report, table DescriptionOfMapUnits
  
        